### PR TITLE
CaseId=>id

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,7 +43,7 @@ router.get('/dsd/code-enforcement', function(req, res) {
           coordinates: [element.Longitude, element.Latitude],
         },
         properties: {
-          "CaseId":element.CaseId,
+          "id":element.CaseId,
           "Description": element.Description,
           "OpenDate":element.OpenDate,
           "CloseDate":element.CloseDate,


### PR DESCRIPTION
As documented in https://github.com/citygram/citygram-services/issues/33 , an the "CaseId" field should be renamed to "id" before our app is added.

I've updated the heroku app; need to merge the code here.
